### PR TITLE
Libruler compatibility

### DIFF
--- a/scripts/libruler.js
+++ b/scripts/libruler.js
@@ -1,0 +1,15 @@
+// Use when libruler is installed
+// https://github.com/caewok/fvtt-lib-ruler
+
+export function scaledDrawDistanceLabel(wrapped) {
+  let label = wrapped();
+  if(label) {
+    //generate scale modifiers from canvas size (assuming default of 100 pixel) and canvas zoom level
+    let gs = canvas.scene.dimensions.size /100
+    let zs = 1/canvas.stage.scale.x
+    label.transform.scale.set(gs+zs)
+    console.log(`easy-ruler-scale|scaled to ${gs+zs}`);
+  }
+  
+  return label;
+}

--- a/scripts/libruler.js
+++ b/scripts/libruler.js
@@ -8,7 +8,6 @@ export function scaledDrawDistanceLabel(wrapped) {
     let gs = canvas.scene.dimensions.size /100
     let zs = 1/canvas.stage.scale.x
     label.transform.scale.set(gs+zs)
-    console.log(`easy-ruler-scale|scaled to ${gs+zs}`);
   }
   
   return label;

--- a/scripts/rulerScale.js
+++ b/scripts/rulerScale.js
@@ -5,12 +5,12 @@ Hooks.once('init', async function () {
   if(game.modules.get('libruler')?.active) {
     Hooks.once('libRulerReady', async function() {
       libWrapper.register(ERS, "window.libRuler.RulerSegment.prototype.drawDistanceLabel", scaledDrawDistanceLabel, "WRAPPED");
-    }
+    });
   } else {
     libWrapper.register(ERS, "Ruler.prototype.measure", newMeasure, "OVERRIDE")
   }
 
-  game.setting.register()
+  //game.settings.register() // requires module and key portion for a setting; looks like this is unneeded as we have no settings.
 });
 
 

--- a/scripts/rulerScale.js
+++ b/scripts/rulerScale.js
@@ -1,9 +1,19 @@
+import { scaledDrawDistanceLabel } from "./libruler.js";
+
 const ERS = "easy-ruler-scale"
 Hooks.once('init', async function () {
+  if(game.modules.get('libruler')?.active) {
+    Hooks.once('libRulerReady', async function() {
+      libWrapper.register(ERS, "window.libRuler.RulerSegment.prototype.drawDistanceLabel", scaledDrawDistanceLabel, "WRAPPED");
+    }
+  } else {
     libWrapper.register(ERS, "Ruler.prototype.measure", newMeasure, "OVERRIDE")
+  }
 
-    game.setting.register()
+  game.setting.register()
 });
+
+
 
 
 function newMeasure(destination, {gridSpaces=true}={}) {

--- a/scripts/rulerScale.js
+++ b/scripts/rulerScale.js
@@ -4,7 +4,7 @@ const ERS = "easy-ruler-scale"
 Hooks.once('init', async function () {
   if(game.modules.get('libruler')?.active) {
     Hooks.once('libRulerReady', async function() {
-      libWrapper.register(ERS, "window.libRuler.RulerSegment.prototype.drawDistanceLabel", scaledDrawDistanceLabel, "WRAPPED");
+      libWrapper.register(ERS, "window.libRuler.RulerSegment.prototype.drawDistanceLabel", scaledDrawDistanceLabel, "WRAPPER");
     });
   } else {
     libWrapper.register(ERS, "Ruler.prototype.measure", newMeasure, "OVERRIDE")


### PR DESCRIPTION
Hi! Someone in the Foundry discord channel was looking for compatibility between Easy Ruler Scale and [libRuler](https://github.com/caewok/fvtt-lib-ruler). This pull request should hopefully accomplish that. Tested in Foundry 0.8.8 with libRuler and [Elevation Ruler](https://github.com/caewok/fvtt-elevation-ruler) and seems to work.

libRuler basically breaks the Ruler methods into more manageable parts. In particular, it adds a `RulerSegment` class that is used to measure and draw each segment (between waypoints). I pulled the relevant scaling code from your `Ruler.measure` override and copied it into `scaledDrawDistanceLabel`. So instead of overriding the entire `Ruler.measure`, this code just wraps the Ruler label when it is created. Specifically, wrapping the `drawDistanceLabel` method that libRuler adds.

I added a check so that if libRuler is not installed, your original patch is used. It is simpler from your perspective to just rely on libRuler, as you wouldn't have to track changes to `Ruler.measure,` but your call. 

Thanks for considering, and let me know if you have questions or issues with this pull request!